### PR TITLE
Support keypad and fix  <RET> behavior

### DIFF
--- a/rpn-calc.el
+++ b/rpn-calc.el
@@ -311,6 +311,25 @@ active."
 
 (defun rpn-calc-self-insert (ch)
   (interactive (list last-input-event))
+  ;; Support keypad keys too
+  (when (symbolp ch)
+    (cond
+     ((string= "kp-add"      (symbol-name ch)) (setq ch ?+))
+     ((string= "kp-subtract" (symbol-name ch)) (setq ch ?-))
+     ((string= "kp-multiply" (symbol-name ch)) (setq ch ?*))
+     ((string= "kp-divide"   (symbol-name ch)) (setq ch ?/))
+     ((string= "kp-0"        (symbol-name ch)) (setq ch ?0))
+     ((string= "kp-1"        (symbol-name ch)) (setq ch ?1))
+     ((string= "kp-2"        (symbol-name ch)) (setq ch ?2))
+     ((string= "kp-3"        (symbol-name ch)) (setq ch ?3))
+     ((string= "kp-4"        (symbol-name ch)) (setq ch ?4))
+     ((string= "kp-5"        (symbol-name ch)) (setq ch ?5))
+     ((string= "kp-6"        (symbol-name ch)) (setq ch ?6))
+     ((string= "kp-7"        (symbol-name ch)) (setq ch ?7))
+     ((string= "kp-8"        (symbol-name ch)) (setq ch ?8))
+     ((string= "kp-9"        (symbol-name ch)) (setq ch ?9))
+     ((string= "kp-decimal"  (symbol-name ch)) (setq ch ?.))
+     (t nil)))
   (with-current-buffer rpn-calc--temp-buffer
     (goto-char (point-max))
     (insert ch)))
@@ -339,9 +358,13 @@ active."
 
 (defun rpn-calc-select ()
   (interactive)
-  (insert
-   (prog1 (popup-item-value (popup-selected-item rpn-calc--popup))
-     (rpn-calc -1))))
+  (let ((return))
+    ;; Return the last valid value from the stack
+    (while (null return)
+      (setq return (popup-item-value (popup-selected-item rpn-calc--popup)))
+      (rpn-calc-previous 1))
+    (insert return))
+  (rpn-calc -1))
 
 ;; + provide
 

--- a/rpn-calc.el
+++ b/rpn-calc.el
@@ -58,8 +58,7 @@
   "list of (NAME ARITY . FUNCTION)."
   :group 'rpn-calc)
 
-(defcustom rpn-calc-incompatible-minor-modes
-  '(phi-autopair-mode key-combo-mode)
+(defcustom rpn-calc-incompatible-minor-modes '()
   "list of minor-modes that should be disabled while RPN calc is
 active."
   :group 'rpn-calc)


### PR DESCRIPTION
- Add support for entering numbers, decimal point and math operators
  from the keypad e.g. `(kbd "<kp-add>")`
- When `RET` is hit after completing an operation (e.g. `23 SPC 12 +
  RET`), `rpn-calc-select` returns an error because `nil` is passed on to
  the `insert` function. This is fixed by doing `(rpn-calc-previous 1)` till
  the return value is non-nil. And the first non-nil return value is
  passed on to the `insert` function.
- Remove references that require other packages
  - The `phi-autopair-mode` and `key-combo-mode` references throw an error   if the user hasn't installed either of those packages.
  - It is safe to keep the default value of   `rpn-calc-incompatible-minor-modes` as `nil` or `'()`. User can then customize this in their init.el.
